### PR TITLE
scripts: add simple script for running on cray

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,6 +31,8 @@ bin_PROGRAMS = \
 	ported/librdmacm/fi_cmatose \
 	complex/fabtest
 
+bin_SCRIPTS = scripts/cray_runall.sh
+
 simple_fi_info_SOURCES = \
 	simple/info.c \
 	common/shared.c

--- a/scripts/cray_runall.sh
+++ b/scripts/cray_runall.sh
@@ -14,9 +14,11 @@ if [ -x /opt/slurm/default/bin/srun ]; then
 #
 timeout=1:00
 launcher="srun -t $timeout"
+one_proc_per_node="--ntasks-per-node=1"
 else
 timeout=60
 launcher="aprun -t $timeout"
+one_proc_per_node="-N 1"
 fi
 tests_failed=0
 tests_passed=0
@@ -45,7 +47,7 @@ nprocs=1
 
 
 echo Running fi_info
-$launcher -n $nprocs $testdir/fi_info 2>&1 | tee test.output
+$launcher -n $nprocs $one_proc_per_node $testdir/fi_info 2>&1 | tee test.output
 if [ $? != 0 ] ; then
   $tests_failed++
 else
@@ -64,7 +66,7 @@ sleep 1
 for test in ${stests[@]} ; do
 
   echo Running $test
-  $launcher -n $nprocs $testdir/$test -f gni
+  $launcher -n $nprocs $one_proc_per_node $testdir/$test -f gni
   if [ $? != 0 ] ; then
     junk=$((tests_failed++))
     failed_tests=("${failed_tests[@]}" $test)

--- a/scripts/cray_runall.sh
+++ b/scripts/cray_runall.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+alps_present=`which alps`
+if [ $? == 0 ]; then
+launcher="aprun -n 1"
+else
+launcher="srun -n 1"
+fi
+echo Running fi_info
+$launcher ./fi_info 2>&1 | tee test.output
+if [ $? != 0 ] ; then
+exit -1
+fi
+count=`grep gni test.output | wc -l`
+if [ $count != 3 ] ; then
+echo "GNI doesn't appear in fi_info about, aborting..." 
+exit -1
+fi
+rm ./test.output
+sleep 1
+echo Running fi_ep_test
+$launcher ./fi_ep_test -f gni
+if [ $? != 0 ] ; then
+exit -1
+fi
+sleep 1
+echo Running fi_dom_test
+$launcher ./fi_dom_test -f gni -n 4
+if [ $? != 0 ] ; then
+exit -1
+fi
+sleep 1
+# fi_av_test doesn't work yet
+#echo Running fi_av_test
+#$launcher ./fi_av_test 
+#if [ $? != 0 ] ; then
+#exit -1
+#fi
+echo ...done 


### PR DESCRIPTION
Simple script which installs into ${FABTESTS_INSTALL}/bin
that can be used to run the few tests that cray gni
provider can currently pass.

Checks for aprun or srun to use to launch tests.

@sungeunchoi 
@ofi-cray/owners 

Signed-off-by: Howard Pritchard howardp@lanl.gov
