### PR TITLE
Changes to cray_runall.sh

### DIFF
--- a/scripts/cray_runall.sh
+++ b/scripts/cray_runall.sh
@@ -8,6 +8,20 @@ usage() {
     exit $ec
 }
 
+my_exit() {
+    echo "==="
+    echo "Total tests run:"$total_tests
+    echo "Tests passed:"$tests_passed
+    echo "Tests failed:"$tests_failed
+    if test $tests_failed -ne 0 ; then
+	echo "Failing tests are:"
+	for ftest in ${failed_tests[@]}; do
+	    echo $ftest
+	done
+    fi
+    exit $tests_failed
+}
+
 if [ -x /opt/slurm/default/bin/srun ]; then
 #
 # slurm uses a hh:mm:ss format, ask for 1 minute
@@ -40,28 +54,39 @@ fi
 # first run single process tests, fi _info is a special test
 #
 
-stests=( fi_ep_test \
-         fi_dom_test )
-
 nprocs=1
+total_tests=1
 
-
+tmp_outfile="test.$$.out"
 echo Running fi_info
-$launcher -n $nprocs $one_proc_per_node $testdir/fi_info 2>&1 | tee test.output
-if [ $? != 0 ] ; then
-  $tests_failed++
+$launcher -n $nprocs $one_proc_per_node $testdir/fi_info 2>&1 > $tmp_outfile
+if [ $? != 0 ]; then
+    echo "fi_info failed, aborting..."
+    junk=$((tests_failed++))
+    failed_tests=("${failed_tests[@]}" "fi_info")
 else
-  count=`grep gni test.output | wc -l`
+  count=`grep gni $tmp_outfile | wc -l`
   if [ $count -lt 3 ] ; then
     echo "GNI doesn't appear in fi_info about, aborting..." 
     junk=$((tests_failed++))
     failed_tests=("${failed_tests[@]}" "fi_info")
   else
     junk=$((tests_passed++))
+    cat $tmp_outfile
   fi
-  rm ./test.output
+fi
+rm $tmp_outfile
+if test $tests_failed -ne 0 ; then
+    # exit if fi_info fails, since we can't rely on anything else
+    my_exit
 fi
 sleep 1
+
+stests=( fi_ep_test \
+         fi_dom_test )
+num_stests=${#stests[@]}
+
+total_tests=$((total_tests+$num_stests))
 
 for test in ${stests[@]} ; do
 
@@ -76,11 +101,4 @@ for test in ${stests[@]} ; do
   sleep 1
 done
 
-echo "Tests passed:"$tests_passed
-echo "Tests failed:"$tests_failed
-if test $tests_failed -ne 0 ; then
-echo "Failing tests are:"
-for ftest in ${failed_tests[@]}; do
-  echo $ftest
-done
-fi
+my_exit


### PR DESCRIPTION
A few modifications to cray_runall.sh that make it easier/cleaner for automated testing:
- move ending stats and exit to my_exit()
- add total number of tests to output
- exit with non-zero status if any tests fail
- redirect fi_info output rather than tee, so as to capture return status
- use a unique filename for fi_info output based on pid
- exit without running other tests if fi_info fails

@bturrubiates @hppritcha 

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
