### PR TITLE
Topic/add client server to crayrunall

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,9 @@ bin_PROGRAMS = \
 	ported/librdmacm/fi_cmatose \
 	complex/fabtest
 
-bin_SCRIPTS = scripts/cray_runall.sh
+bin_SCRIPTS = \
+	scripts/cray_runall.sh \
+	scripts/run_client_server.sh
 
 simple_fi_info_SOURCES = \
 	simple/info.c \

--- a/scripts/cray_runall.sh
+++ b/scripts/cray_runall.sh
@@ -1,6 +1,42 @@
 #!/bin/bash
 #
+# Copyright (c) 2015 Cray Inc.  All rights reserved.
+# Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+#
+# This software is available to you under a choice of one of two
+# licenses.  You may choose to be licensed under the terms of the GNU
+# General Public License (GPL) Version 2, available from the file
+# COPYING in the main directory of this source tree, or the
+# BSD license below:
+#
+#     Redistribution and use in source and binary forms, with or
+#     without modification, are permitted provided that the following
+#     conditions are met:
+#
+#      - Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      - Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials
+#        provided with the distribution.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
 
+#
+# globals:
+#   provider to use for client/server "simple" tests
+cs_provider="sockets"
+ 
 usage() {
     ec=$1
     echo "cray_runall.sh [-d <dir>]"
@@ -22,14 +58,55 @@ my_exit() {
     exit $tests_failed
 }
 
+#
+# srun specific function to run the client/server tests
+# in simpledirectory.  This function assumes the client and
+# server are run on the same node.
+#
+
+run_client_server_srun() {
+    local prog_name=$1
+    local fabric=$2
+    local gni_ip_addr=`/sbin/ifconfig ipogif0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}'`
+    if [ -f mpmd_conf_file ] ; then
+        rm mpmd_conf_file
+    fi
+    echo  "0  run_client_server.sh -t $prog_name -f $fabric">> mpmd_conf_file
+    echo  "1  run_client_server.sh -t $prog_name -f $fabric -c">> mpmd_conf_file
+#   cat mpmd_conf_file
+#
+# the exclusive option seems necessary for MPMD
+#
+    $launcher --multi-prog --exclusive -N 1 -t $timeout mpmd_conf_file
+    return $?
+}
+
+#
+# the aprun method assume one is running the script
+# in a batch environment, so the first invocation of
+# aprun will put a rank on the same node as for the
+# second invocation.
+#
+
+run_client_server_aprun() {
+    local prog_name=$1
+    local gni_ip_addr=`aprun -n 1 /sbin/ifconfig ipogif0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}'`
+    echo  "0: $prog_name" >> mpmd_conf_file
+    echo  "1: $prog_name $gni_ip_addr" >> mpmd_conf_file
+    $launcher -n 1 $prog_name : -n 1 $ prog_name $gni_ip_addr
+    return $?
+}
+
 if [ -x /opt/slurm/default/bin/srun ]; then
 #
 # slurm uses a hh:mm:ss format, ask for 1 minute
 #
+using_alps=0
 timeout=1:00
 launcher="srun -t $timeout"
 one_proc_per_node="--ntasks-per-node=1"
 else
+using_alps=1
 timeout=60
 launcher="aprun -t $timeout"
 one_proc_per_node="-N 1"
@@ -100,6 +177,45 @@ for test in ${stests[@]} ; do
     junk=$((tests_passed++))
   fi
   sleep 1
+done
+
+cs_tests=(fi_msg\
+          fi_msg_pingpong \
+          fi_msg_rma \
+          fi_rdm \
+          fi_rdm_rma_simple \
+          fi_dgram \
+          fi_dgram_waitset \
+          fi_rdm_pingpong \
+          fi_rdm_tagged_pingpong \
+          fi_rdm_tagged_search \
+          fi_rdm_cntr_pingpong \
+          fi_rdm_rma \
+          fi_rdm_atomic \
+          fi_ud_pingpong \
+          fi_cq_data \
+          fi_poll \
+          fi_rdm_inject_pingpong \
+          fi_rdm_multi_recv \
+          fi_scalable_ep \
+          fi_rdm_shared_ctx )
+
+num_cs_tests=${#cs_tests[@]}
+
+total_tests=$((total_tests+$num_cs_tests))
+
+for test in ${cs_tests[@]} ; do
+
+  echo Running $test using provider $cs_provider
+  run_client_server_srun $test $cs_provider
+  if [ $? != 0 ] ; then
+    junk=$((tests_failed++))
+    failed_tests=("${failed_tests[@]}" $test)
+  else
+    junk=$((tests_passed++))
+  fi
+  sleep 1
+
 done
 
 my_exit

--- a/scripts/run_client_server.sh
+++ b/scripts/run_client_server.sh
@@ -66,11 +66,9 @@ fi
 
 gni_ip_addr=`/sbin/ifconfig ipogif0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}'`
 if [ $run_client -eq 1 ] ; then
-#$testprog -f $fabric $gni_ip_addr
-$testprog $gni_ip_addr
+$testprog -f $fabric $gni_ip_addr
 else
-#$testprog -f $fabric
-$testprog
+$testprog -f $fabric
 fi
 
 

--- a/scripts/run_client_server.sh
+++ b/scripts/run_client_server.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Copyright (c) 2015 Cray Inc.  All rights reserved.
+# Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+#
+# This software is available to you under a choice of one of two
+# licenses.  You may choose to be licensed under the terms of the GNU
+# General Public License (GPL) Version 2, available from the file
+# COPYING in the main directory of this source tree, or the
+# BSD license below:
+#
+#     Redistribution and use in source and binary forms, with or
+#     without modification, are permitted provided that the following
+#     conditions are met:
+#
+#      - Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      - Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials
+#        provided with the distribution.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AWV
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# Helper script to assist in running the fabtest
+# client/server tests in the slurm environment.
+# The script is intended to be used with both client
+# and server running on the same node.
+#
+
+usage() {
+    ec=$1
+    echo "cray_run_client_server.sh -t <test> [-f <fabric>] [-c]"
+    echo "   -t name_of_client_server_test"
+    echo "   -f fabric"
+    echo "   -c run test as client if set"
+    exit $ec
+}
+
+if [ $# -lt 2 ] ; then
+usage 1
+fi
+
+run_client=0
+fabric="sockets"
+if [ $# -gt 0 ] ; then
+  while getopts "t:f:c" option; do
+    case $option in
+      t) testprog=$OPTARG;;
+      f) fabric=$OPTARG;;
+      c) run_client=1;;
+      *) usage 1;;
+    esac
+  done
+  shift $(($OPTIND-1))
+fi
+
+gni_ip_addr=`/sbin/ifconfig ipogif0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}'`
+if [ $run_client -eq 1 ] ; then
+#$testprog -f $fabric $gni_ip_addr
+$testprog $gni_ip_addr
+else
+#$testprog -f $fabric
+$testprog
+fi
+
+
+

--- a/scripts/run_client_server.sh
+++ b/scripts/run_client_server.sh
@@ -39,7 +39,7 @@
 
 usage() {
     ec=$1
-    echo "cray_run_client_server.sh -t <test> [-f <fabric>] [-c]"
+    echo "cray_run_client_server.sh -t <test> [-f <fabric>] [-c] [-a <app args>]"
     echo "   -t name_of_client_server_test"
     echo "   -f fabric"
     echo "   -c run test as client if set"
@@ -53,11 +53,12 @@ fi
 run_client=0
 fabric="sockets"
 if [ $# -gt 0 ] ; then
-  while getopts "t:f:c" option; do
+  while getopts "t:f:ca:" option; do
     case $option in
       t) testprog=$OPTARG;;
       f) fabric=$OPTARG;;
       c) run_client=1;;
+      a) app_args=$OPTARG;;
       *) usage 1;;
     esac
   done
@@ -66,9 +67,9 @@ fi
 
 gni_ip_addr=`/sbin/ifconfig ipogif0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}'`
 if [ $run_client -eq 1 ] ; then
-$testprog -f $fabric $gni_ip_addr
+$testprog -f $fabric $app_args $gni_ip_addr
 else
-$testprog -f $fabric
+$testprog -f $fabric $app_args
 fi
 
 


### PR DESCRIPTION
Add some infrastructure in the cray runall script to run the client/server tests in the "simple" directory on systems using srun or aprun to launch on to the compute nodes.

The script by default picks the sockets fabric for these tests.  Several of them currently fail with segfaults on tiger.  

@sungeunchoi 

Signed-off-by: Howard Pritchard hppritcha@gmail.com
