### PR TITLE
Implement FT_Allgather, FT_Broadcast utilities on non-Cray PMIs.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -208,6 +208,10 @@ dist-hook: fabtests.spec
 if HAVE_PMI
 AM_CFLAGS += -lpmi
 
+if HAVE_CRAY_PMI
+AM_CFLAGS += -DCRAY_PMI_COLL
+endif
+
 bin_PROGRAMS += \
 	perf/rdm_bw \
 	perf/rdm_latency

--- a/configure.ac
+++ b/configure.ac
@@ -67,9 +67,14 @@ AC_ARG_WITH([pmi],
             AC_HELP_STRING([--with-pmi], [Specify PMI location - default NO]),
             [AS_IF([test -d $withval/lib64], [pmi_libdir="lib64"], [pmi_libdir="lib"])
              CPPFLAGS="-I $withval/include $CPPFLAGS"
+             CPPFLAGS="-I $withval $CPPFLAGS"
              LDFLAGS="-L$withval/$pmi_libdir $LDFLAGS"
              AM_CONDITIONAL([HAVE_PMI], [true])],
             [AM_CONDITIONAL([HAVE_PMI], [false])])
+
+AC_CHECK_LIB([pmi], [PMI_Allgather],
+	     AM_CONDITIONAL([HAVE_CRAY_PMI], [true]),
+	     AM_CONDITIONAL([HAVE_CRAY_PMI], [false]))
 
 dnl Checks for libraries
 AC_CHECK_LIB([fabric], fi_getinfo, [],

--- a/perf/ft_utils.h
+++ b/perf/ft_utils.h
@@ -41,7 +41,6 @@ void FT_Init(int *,char ***);
 void FT_Abort(void);
 void FT_Exit(void);
 void FT_Rank(int *);
-void FT_Npes(int *);
 void FT_Finalize(void);
 void FT_Barrier(void);
 void FT_Job_size(int *);


### PR DESCRIPTION
Fixes ofi-cray/fabtests-cray#18.

Signed-off-by: Zachary Tiffany <ztiffany@osprey-esl.(none)>

@hppritcha please review.

I built and ran the perf tests on osprey and tiger.  --with-pmi can point straight to the directory with pmi.h or to a PMI install prefix like /opt/cray/pmi/default on an XC.
