### PR TITLE
Move fabtest to intermittent error list

### DIFF
--- a/scripts/cray_runall_expected_failures
+++ b/scripts/cray_runall_expected_failures
@@ -2,5 +2,4 @@
 # These 2 tests work in loop-back mode, but not on distinct nodes
 fi_rdm_tagged_search
 fi_rdm_shared_ctx
-fabtest
 

--- a/scripts/cray_runall_intermittent_failures
+++ b/scripts/cray_runall_intermittent_failures
@@ -1,2 +1,3 @@
 # intermittent failures, one per line
+fabtest
 fi_msg


### PR DESCRIPTION
fabtest ran to completion (i.e., did not timeout), so moving to the intermittent list.

FYI @hppritcha 
