### PR TITLE
handle case where there's no CLOCK_REALTIME_COARSE

### DIFF
--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -47,6 +47,10 @@
 
 #include "shared.h"
 
+#ifndef CLOCK_REALTIME_COARSE
+#define CLOCK_REALTIME_COARSE CLOCK_REALTIME
+#endif
+
 static struct cs_opts opts;
 static int max_credits = 128;
 static int credits = 128;


### PR DESCRIPTION
The addition of CLOCK_REALTIME_COARSE usage without a
check for it being defined or not breaks fabtests
build on some linux distros.

Fixes #24 

Signed-off-by: Howard Pritchard howardp@lanl.gov
