### PR TITLE
Reclassify failing tests

### DIFF
--- a/scripts/cray_runall_expected_failures
+++ b/scripts/cray_runall_expected_failures
@@ -1,5 +1,4 @@
 # expected failures, one per line
 # These 2 tests work in loop-back mode, but not on distinct nodes
 fi_rdm_tagged_search
-fi_rdm_shared_ctx
 

--- a/scripts/cray_runall_intermittent_failures
+++ b/scripts/cray_runall_intermittent_failures
@@ -1,3 +1,4 @@
 # intermittent failures, one per line
 fabtest
 fi_msg
+fi_ud_pingpong


### PR DESCRIPTION
Remove fi_rdm_shared_ctx from expected list; add fi_ud_pingpong to intermittent list

This should quiet testing.

@hppritcha 
