### PR TITLE
Fix OSU-based test capabilities

### DIFF
--- a/ported/osu/rdm_bw.c
+++ b/ported/osu/rdm_bw.c
@@ -318,7 +318,7 @@ int main(int argc, char *argv[])
 	}
 
 	hints->ep_attr->type	= FI_EP_RDM;
-	hints->caps		= FI_MSG | FI_RMA;
+	hints->caps		= FI_MSG | FI_DIRECTED_RECV | FI_RMA;
 	hints->mode		= FI_CONTEXT | FI_LOCAL_MR;
 	hints->domain_attr->mr_mode = FI_MR_BASIC;
 

--- a/ported/osu/rdm_latency.c
+++ b/ported/osu/rdm_latency.c
@@ -307,7 +307,7 @@ int main(int argc, char *argv[])
 	}
 
 	hints->ep_attr->type	= FI_EP_RDM;
-	hints->caps		= FI_MSG;
+	hints->caps		= FI_MSG | FI_DIRECTED_RECV;
 	hints->mode		= FI_CONTEXT | FI_LOCAL_MR;
 
 	if (numprocs != 2) {

--- a/ported/osu/rdm_mbw_mr.c
+++ b/ported/osu/rdm_mbw_mr.c
@@ -452,7 +452,7 @@ int main(int argc, char *argv[])
 	}
 
 	hints->ep_attr->type	= FI_EP_RDM;
-	hints->caps		= FI_MSG;
+	hints->caps		= FI_MSG | FI_DIRECTED_RECV;
 	hints->mode		= FI_CONTEXT | FI_LOCAL_MR;
 
 	if (numprocs < 2) {


### PR DESCRIPTION
Request FI_DIRECTED_RECV in the OSU-based fabtests.  This capability is
required when posting a recv to a specific address.

Signed-off-by: Zach Tiffany ztiffany@cray.com

@sungeunchoi 
