### PR TITLE
ported/omb: limit send/recv test to 8192 bytes

### DIFF
--- a/ported/omb/rdm_latency.c
+++ b/ported/omb/rdm_latency.c
@@ -51,7 +51,11 @@
 #include "shared.h"
 
 #define MAX_ALIGNMENT 65536
-#define MAX_MSG_SIZE (1<<22)
+/*
+ * restrict message size to less than the SMSG mailbox threshold
+ * for now, which is 16384 - sizeof-of-gni-prov internal header
+ */
+#define MAX_MSG_SIZE (1<<13)
 #define MYBUFSIZE (MAX_MSG_SIZE + MAX_ALIGNMENT)
 
 #define TEST_DESC "Libfabric Latency Test"


### PR DESCRIPTION
Currently gni provider only supports send/recv using GNI_SmsgSend(WTag)
which owing to our mbox size means no more than 16384 bytes.
Note that due to a gni provider internal header, the actual
max send/recv size for an app is less than 16384 bytes.

this commit temporarily caps the transfer size at 8192.

@sungeunchoi 

Signed-off-by: Howard Pritchard howardp@lanl.gov
