### PR TITLE
Revert "handle case where there's no CLOCK_REALTIME_COARSE"

### DIFF
--- a/pingpong/ud_pingpong.c
+++ b/pingpong/ud_pingpong.c
@@ -47,10 +47,6 @@
 
 #include "shared.h"
 
-#ifndef CLOCK_REALTIME_COARSE
-#define CLOCK_REALTIME_COARSE CLOCK_REALTIME
-#endif
-
 static struct cs_opts opts;
 static int max_credits = 128;
 static int credits = 128;


### PR DESCRIPTION
This reverts commit e8e073e43fcf5cb206ebef07053ad873feb96f86.

The problem is fixed with upstream commit
ea0cb0e218855cbfcca9d5b20487e604d50100e9.  I will merge this after merging the upstream commit.

Fixes #24 

@hppritcha 
