### PR TITLE
Fix build due to upstream commit e93a61cb2487fc181883e78426d2d1c893e61f5d

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -168,7 +168,7 @@ unit_fi_av_test_LDADD = libfabtests.la
 unit_fi_av_test2_SOURCES = \
 	unit/av_test2.c \
 	unit/common.c
-unit_fi_size_left_test_LDADD = libfabtests.la
+unit_fi_av_test2_LDADD = libfabtests.la
 
 unit_fi_dom_test_SOURCES = \
 	unit/dom_test.c \
@@ -178,14 +178,17 @@ unit_fi_dom_test_LDADD = libfabtests.la
 unit_fi_ep_test_SOURCES = \
 	unit/ep_test.c \
 	unit/common.c
+unit_fi_ep_test_LDADD = libfabtests.la
 
 unit_fi_multi_dom_test_SOURCES = \
 	unit/multi_dom_test.c \
 	unit/common.c
+unit_fi_multi_dom_test_LDADD = libfabtests.la
 
 unit_fi_size_left_test_SOURCES = \
 	unit/size_left_test.c \
 	unit/common.c
+unit_fi_size_left_test_LDADD = libfabtests.la
 
 ported_libibverbs_fi_rc_pingpong_SOURCES = \
 	ported/libibverbs/rc_pingpong.c

--- a/unit/av_test2.c
+++ b/unit/av_test2.c
@@ -56,15 +56,8 @@
 
 #define MAX_ADDR 256
 
-struct fi_info *hints = NULL;
 static struct fi_fabric_attr fabric_hints;
 static struct fi_eq_attr eq_attr;
-
-static struct fi_info *fi = NULL;
-static struct fid_fabric *fabric = NULL;
-static struct fid_domain *domain = NULL;
-static struct fid_eq *eq = NULL;
-static struct fid_ep *ep = NULL;
 
 int async_avail = 1;  /* be optimistic */
 int test_map_type = 0;

--- a/unit/ep_test.c
+++ b/unit/ep_test.c
@@ -57,12 +57,6 @@
 
 #define MAX_ADDR 256
 
-static struct fi_info *hints;
-static struct fi_info *fi;
-static struct fid_fabric *fabric;
-static struct fid_domain *domain;
-static struct fid_ep *ep;
-
 /*
  * Tests:
  * - test open and close of an endpoint

--- a/unit/multi_dom_test.c
+++ b/unit/multi_dom_test.c
@@ -58,9 +58,6 @@
 
 #define MAX_ADDR 256
 
-static struct fi_info *hints;
-static struct fi_info *fi;
-static struct fid_fabric *fabric;
 static struct fid_domain **domains;
 static struct fid_ep **eps;
 


### PR DESCRIPTION
Remove duplicate definitions due to upstream changes (the above commit moved common declarations to shared.[ch]).  Makefile changes were necessary because we were not previous linking with the libfabtests library (maybe that was an accident).

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com

@hppritcha @jswaro 
