### PR TITLE
Remove eq_attr definition as per upstream commit

### DIFF
--- a/unit/av_test2.c
+++ b/unit/av_test2.c
@@ -57,7 +57,6 @@
 #define MAX_ADDR 256
 
 static struct fi_fabric_attr fabric_hints;
-static struct fi_eq_attr eq_attr;
 
 int async_avail = 1;  /* be optimistic */
 int test_map_type = 0;


### PR DESCRIPTION
Commit 2e605007fb22290ddb8117ba86ac66d119ad9861 moved eq_attr into shared.h.

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com

@hppritcha @jswaro @jshimek @ztiffany 
