### PR TITLE
Add --cpu_bind=none flag to srun commands

### DIFF
--- a/scripts/run_client_server.py
+++ b/scripts/run_client_server.py
@@ -59,7 +59,7 @@ class fabtest:
     def start(self):
         cmd = list()
         if self.launcher == 'srun':
-            cmd += ['srun', '-N'+self.nnodes, '--exclusive', '-t'+self.formattedTimeout()]
+            cmd += ['srun', '-N'+self.nnodes, '--exclusive', '--cpu_bind=none', '-t'+self.formattedTimeout()]
             if self.ntasks != '-1':
                 cmd += [ '-n'+self.ntasks ]
             else:


### PR DESCRIPTION
This disables the default auto binding.

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com

@hppritcha @ztiffany @jswaro @jshimek 
