### PR TITLE
ported/omb: simple workaround for share changes

### DIFF
--- a/ported/omb/rdm_bw.c
+++ b/ported/omb/rdm_bw.c
@@ -2,6 +2,7 @@
  * Copyright (C) 2002-2012 the Network-Based Computing Laboratory
  * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
  * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -105,6 +106,50 @@ void print_usage(void)
 	if (!myid)
 		ft_basic_usage(TEST_DESC);
 }
+
+static void cq_readerr(struct fid_cq *cq, const char *cq_str)
+{
+	struct fi_cq_err_entry cq_err;
+	const char *err_str;
+	int ret;
+
+	ret = fi_cq_readerr(cq, &cq_err, 0);
+	if (ret < 0) {
+		FT_PRINTERR("fi_cq_readerr", ret);
+	} else {
+		err_str = fi_cq_strerror(cq, cq_err.prov_errno, cq_err.err_data,
+					NULL, 0);
+		fprintf(stderr, "%s: %d %s\n", cq_str, cq_err.err,
+			fi_strerror(cq_err.err));
+		fprintf(stderr, "%s: prov_err: %s (%d)\n", cq_str, err_str,
+			cq_err.prov_errno);
+	}
+}
+
+/*
+ * fi_cq_err_entry can be cast to any CQ entry format.
+ */
+static int ft_wait_for_comp_omb(struct fid_cq *cq, int num_completions)
+{
+	struct fi_cq_err_entry comp;
+	int ret;
+
+	while (num_completions > 0) {
+		ret = fi_cq_read(cq, &comp, 1);
+		if (ret > 0) {
+			num_completions--;
+		} else if (ret < 0 && ret != -FI_EAGAIN) {
+			if (ret == -FI_EAVAIL) {
+				cq_readerr(cq, "cq");
+			} else {
+				FT_PRINTERR("fi_cq_read", ret);
+			}
+			return ret;
+		}
+	}
+	return 0;
+}
+
 
 static void free_ep_res(void)
 {
@@ -415,7 +460,7 @@ int main(int argc, char *argv[])
 					}
 				}
 
-				ft_wait_for_comp(scq, window_size);
+				ft_wait_for_comp_omb(scq, window_size);
 			}
 
 			t_end = get_time_usec();

--- a/ported/omb/rdm_latency_threaded.c
+++ b/ported/omb/rdm_latency_threaded.c
@@ -2,6 +2,7 @@
  * Copyright (C) 2002-2012 the Network-Based Computing Laboratory
  * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
  * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -122,6 +123,49 @@ void print_usage(void)
 {
 	if (!myid)
 		ft_basic_usage(TEST_DESC);
+}
+
+static void cq_readerr(struct fid_cq *cq, const char *cq_str)
+{
+	struct fi_cq_err_entry cq_err;
+	const char *err_str;
+	int ret;
+
+	ret = fi_cq_readerr(cq, &cq_err, 0);
+	if (ret < 0) {
+		FT_PRINTERR("fi_cq_readerr", ret);
+	} else {
+		err_str = fi_cq_strerror(cq, cq_err.prov_errno, cq_err.err_data,
+					NULL, 0);
+		fprintf(stderr, "%s: %d %s\n", cq_str, cq_err.err,
+			fi_strerror(cq_err.err));
+		fprintf(stderr, "%s: prov_err: %s (%d)\n", cq_str, err_str,
+			cq_err.prov_errno);
+	}
+}
+
+/*
+ * fi_cq_err_entry can be cast to any CQ entry format.
+ */
+static int ft_wait_for_comp_omb(struct fid_cq *cq, int num_completions)
+{
+	struct fi_cq_err_entry comp;
+	int ret;
+
+	while (num_completions > 0) {
+		ret = fi_cq_read(cq, &comp, 1);
+		if (ret > 0) {
+			num_completions--;
+		} else if (ret < 0 && ret != -FI_EAGAIN) {
+			if (ret == -FI_EAVAIL) {
+				cq_readerr(cq, "cq");
+			} else {
+				FT_PRINTERR("fi_cq_read", ret);
+			}
+			return ret;
+		}
+	}
+	return 0;
 }
 
 static void free_ep_res(struct per_thread_data *ptd)
@@ -395,12 +439,12 @@ void *thread_fn(void *data)
 			fi_rc = fi_tsend(ptd->ep, ptd->s_buf, size, NULL,
 					ptd->fi_addrs[peer], 0xDEADBEEF, NULL);
 			assert(!fi_rc);
-			ft_wait_for_comp(ptd->scq, 1);
+			ft_wait_for_comp_omb(ptd->scq, 1);
 
 			fi_rc = fi_trecv(ptd->ep, ptd->r_buf, size, NULL,
 					ptd->fi_addrs[peer], 0xDEADBEEF, 0, NULL);
 			assert(!fi_rc);
-			ft_wait_for_comp(ptd->rcq, 1);
+			ft_wait_for_comp_omb(ptd->rcq, 1);
 		}
 
 		t_end = get_time_usec();
@@ -410,12 +454,12 @@ void *thread_fn(void *data)
 			fi_rc = fi_trecv(ptd->ep, ptd->r_buf, size, NULL,
 					ptd->fi_addrs[peer], 0xDEADBEEF, 0, NULL);
 			assert(!fi_rc);
-			ft_wait_for_comp(ptd->rcq, 1);
+			ft_wait_for_comp_omb(ptd->rcq, 1);
 
 			fi_rc = fi_tsend(ptd->ep, ptd->s_buf, size, NULL,
 					ptd->fi_addrs[peer], 0xDEADBEEF, NULL);
 			assert(!fi_rc);
-			ft_wait_for_comp(ptd->scq, 1);
+			ft_wait_for_comp_omb(ptd->scq, 1);
 		}
 	}
 

--- a/ported/omb/rdm_mbw_mr.c
+++ b/ported/omb/rdm_mbw_mr.c
@@ -2,6 +2,7 @@
  * Copyright (C) 2002-2012 the Network-Based Computing Laboratory
  * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
  * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -118,6 +119,49 @@ static void free_ep_res(void)
 	fi_close(&av->fid);
 	fi_close(&rcq->fid);
 	fi_close(&scq->fid);
+}
+
+static void cq_readerr(struct fid_cq *cq, const char *cq_str)
+{
+	struct fi_cq_err_entry cq_err;
+	const char *err_str;
+	int ret;
+
+	ret = fi_cq_readerr(cq, &cq_err, 0);
+	if (ret < 0) {
+		FT_PRINTERR("fi_cq_readerr", ret);
+	} else {
+		err_str = fi_cq_strerror(cq, cq_err.prov_errno, cq_err.err_data,
+					NULL, 0);
+		fprintf(stderr, "%s: %d %s\n", cq_str, cq_err.err,
+			fi_strerror(cq_err.err));
+		fprintf(stderr, "%s: prov_err: %s (%d)\n", cq_str, err_str,
+			cq_err.prov_errno);
+	}
+}
+
+/*
+ * fi_cq_err_entry can be cast to any CQ entry format.
+ */
+static int ft_wait_for_comp_omb(struct fid_cq *cq, int num_completions)
+{
+	struct fi_cq_err_entry comp;
+	int ret;
+
+	while (num_completions > 0) {
+		ret = fi_cq_read(cq, &comp, 1);
+		if (ret > 0) {
+			num_completions--;
+		} else if (ret < 0 && ret != -FI_EAGAIN) {
+			if (ret == -FI_EAVAIL) {
+				cq_readerr(cq, "cq");
+			} else {
+				FT_PRINTERR("fi_cq_read", ret);
+			}
+			return ret;
+		}
+	}
+	return 0;
 }
 
 static int alloc_ep_res(void)
@@ -336,11 +380,11 @@ double calc_bw(int rank, int size, int num_pairs, int window_size, char *s_buf,
 				assert(!fi_rc);
 			}
 
-			ft_wait_for_comp(scq, window_size);
+			ft_wait_for_comp_omb(scq, window_size);
 			fi_rc = fi_recv(ep, r_buf, 4, NULL,
 					fi_addrs[target], NULL);
 			assert(!fi_rc);
-			ft_wait_for_comp(rcq, 1);
+			ft_wait_for_comp_omb(rcq, 1);
 		}
 
 		t_end = get_time_usec();
@@ -359,11 +403,11 @@ double calc_bw(int rank, int size, int num_pairs, int window_size, char *s_buf,
 				assert(!fi_rc);
 			}
 
-			ft_wait_for_comp(rcq, window_size);
+			ft_wait_for_comp_omb(rcq, window_size);
 			fi_rc = fi_send(ep, s_buf, 4, NULL,
 					fi_addrs[target], NULL);
 			assert(!fi_rc);
-			ft_wait_for_comp(scq, 1);
+			ft_wait_for_comp_omb(scq, 1);
 		}
 	} else {
 		FT_Barrier();


### PR DESCRIPTION
The definition of ft_wait_for_comp was changed
in upstream fabtests that busted cray/lanl ported/omb
tests.

Do a simple change for now to fix this.

@sungeunchoi 

Signed-off-by: Howard Pritchard howardp@lanl.gov
