### PR TITLE
Removing fi_eq_test from expected failures

### DIFF
--- a/scripts/cray_runall_expected_failures
+++ b/scripts/cray_runall_expected_failures
@@ -1,5 +1,4 @@
 # expected failures, one per line
-fi_eq_test
 fi_size_left_test
 fi_msg_pingpong
 fi_ud_pingpong


### PR DESCRIPTION
Upstream commit f0d27d3 changed the tests to mark test that use APIs
that are unimplemented as skipped rather than failed.

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com

@hppritcha 
