### PR TITLE
Fix computation of bandwidth estimate

### DIFF
--- a/ported/omb/rdm_bw_threaded.c
+++ b/ported/omb/rdm_bw_threaded.c
@@ -460,8 +460,9 @@ void *thread_fn(void *data)
 		peer = 1;
 
 		for (i = 0; i < loop + skip; i++) {
-			if (i == skip) {
+			if (i == skip) {  /* warm up loop */
 				t_start = get_time_usec();
+				ptd->bytes_sent = 0;
 			}
 
 			for (j = 0; j < window_size; j++) {


### PR DESCRIPTION
The bandwidth is over-estimated because the bytes sent during the
warm up loop are added into the overall bytes sent. This commit
resets the bytes sent at the end of the warm up loops.

Signed-off-by: James Swaro jswaro@cray.com

@hppritcha @chuckfossen @e-harvey Review when possible please.
