### PR TITLE
Request FI_TAGGED capability for rdm_latency* tests

### DIFF
--- a/ported/omb/rdm_latency.c
+++ b/ported/omb/rdm_latency.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2002-2012 the Network-Based Computing Laboratory
  * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -356,7 +356,7 @@ int main(int argc, char *argv[])
 	}
 
 	hints->ep_attr->type	= FI_EP_RDM;
-	hints->caps		= FI_MSG | FI_DIRECTED_RECV;
+	hints->caps		= FI_TAGGED | FI_DIRECTED_RECV;
 	hints->mode		= FI_CONTEXT | FI_LOCAL_MR;
 
 	if (numprocs != 2) {

--- a/ported/omb/rdm_latency_threaded.c
+++ b/ported/omb/rdm_latency_threaded.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2002-2012 the Network-Based Computing Laboratory
  * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -514,7 +514,7 @@ int main(int argc, char *argv[])
 	}
 
 	hints->ep_attr->type	= FI_EP_RDM;
-	hints->caps		= FI_MSG | FI_DIRECTED_RECV;
+	hints->caps		= FI_TAGGED | FI_DIRECTED_RECV;
 	hints->mode		= FI_CONTEXT | FI_LOCAL_MR;
 
 	if (numprocs != 2) {


### PR DESCRIPTION
This was mistakenly not updated when we changed the test to use tagged send/recv.

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com

Fixes #62 

@chuckfossen 
