### PR TITLE
Remove fi_rdm_inject_pingpong test

### DIFF
--- a/scripts/cray_runall.sh
+++ b/scripts/cray_runall.sh
@@ -263,7 +263,6 @@ done
 pingpong=( \
      fi_msg_pingpong \
      fi_rdm_cntr_pingpong \
-     fi_rdm_inject_pingpong \
      fi_rdm_pingpong \
      fi_rdm_tagged_pingpong \
      fi_ud_pingpong )


### PR DESCRIPTION
This was removed by the upstream, when the pingpong tests were
rewritten and moved to the benchmarks directory.

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
