### PR TITLE
Remove datagram pingpong tests from expected failures list.

### DIFF
--- a/scripts/cray_runall_expected_failures
+++ b/scripts/cray_runall_expected_failures
@@ -1,4 +1,3 @@
 # expected failures, one per line
 fi_size_left_test
 fi_msg_pingpong
-fi_ud_pingpong


### PR DESCRIPTION
Datagram endpoint type implemented by https://github.com/ofi-cray/libfabric-cray/pull/700

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com

@chuckfossen 
