### PR TITLE
Fix calls to fi_ep_bind() to use the correct flags

### DIFF
--- a/ported/omb/rdm_bw.c
+++ b/ported/omb/rdm_bw.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2002-2012 the Network-Based Computing Laboratory
  * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -211,7 +211,7 @@ static int bind_ep_res(void)
 	int ret;
 
 	/* Bind Send CQ with endpoint to collect send completions */
-	ret = fi_ep_bind(ep, &scq->fid, FI_SEND|FI_WRITE);
+	ret = fi_ep_bind(ep, &scq->fid, FI_TRANSMIT);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;

--- a/ported/omb/rdm_latency.c
+++ b/ported/omb/rdm_latency.c
@@ -205,7 +205,7 @@ static int bind_ep_res(void)
 	int ret;
 
 	/* Bind Send CQ with endpoint to collect send completions */
-	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
+	ret = fi_ep_bind(ep, &scq->fid, FI_TRANSMIT);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;

--- a/ported/omb/rdm_mbw_mr.c
+++ b/ported/omb/rdm_mbw_mr.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2002-2012 the Network-Based Computing Laboratory
  * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -217,7 +217,7 @@ static int bind_ep_res(void)
 	int ret;
 
 	/* Bind Send CQ with endpoint to collect send completions */
-	ret = fi_ep_bind(ep, &scq->fid, FI_SEND);
+	ret = fi_ep_bind(ep, &scq->fid, FI_TRANSMIT);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;

--- a/ported/omb/rdm_pingpong.c
+++ b/ported/omb/rdm_pingpong.c
@@ -232,7 +232,7 @@ static int bind_ep_res(struct per_thread_data *ptd)
 	int ret;
 
 	/* Bind Send CQ with endpoint to collect send completions */
-	ret = fi_ep_bind(ptd->ep, &ptd->scq->fid, FI_SEND|FI_WRITE);
+	ret = fi_ep_bind(ptd->ep, &ptd->scq->fid, FI_TRANSMIT);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;

--- a/ported/omb/rdma_one_sided.c
+++ b/ported/omb/rdma_one_sided.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2002-2012 the Network-Based Computing Laboratory
  * Copyright (c) 2013-2014 Intel Corporation.  All rights reserved.
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -252,7 +252,7 @@ static int bind_ep_res(struct per_thread_data *ptd)
 	int ret;
 
 	/* Bind Send CQ with endpoint to collect send completions */
-	ret = fi_ep_bind(ptd->ep, &ptd->scq->fid, FI_SEND|FI_WRITE);
+	ret = fi_ep_bind(ptd->ep, &ptd->scq->fid, FI_TRANSMIT);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
 		return ret;


### PR DESCRIPTION
Found these due to new checks added in upstream commit bc8de029.

Signed-off-by: Sung-Eun Choi sungeunchoi@users.noreply.github.com
